### PR TITLE
APM-36: Drop `GetServiceProviders` op related policies

### DIFF
--- a/policies/service/authz/access/data.yaml
+++ b/policies/service/authz/access/data.yaml
@@ -176,7 +176,6 @@ api:
       - "GetCountryByID"
       - "GetTradeBlocs"
       - "GetTradeBlocByID"
-      - "GetServiceProviders"
       - "GetServiceProviderByID"
       - "GetLocationsNames"
       - "GetPaymentInstitutions"

--- a/policies/service/authz/methods/data.yaml
+++ b/policies/service/authz/methods/data.yaml
@@ -147,7 +147,6 @@ permissions:
           - "GetPaymentInstitutionPayoutSchedules"
 
           # ServiceProviders
-          - "GetServiceProviders"
           - "GetServiceProviderByID"
 
           # Webhooks
@@ -352,7 +351,6 @@ permissions:
           - "GetPaymentInstitutionPayoutSchedules"
 
           # ServiceProviders
-          - "GetServiceProviders"
           - "GetServiceProviderByID"
 
           # Webhooks

--- a/test/test/service/authz/api/capi_test.rego
+++ b/test/test/service/authz/api/capi_test.rego
@@ -500,7 +500,7 @@ test_get_tradeblocs_allowed_by_api_token {
 }
 
 test_get_service_providers_allowed_by_api_token {
-    util.is_allowed with input as capi_public_operation_api_token_ctx with input.capi.op as {"id" : "GetServiceProviders"}
+    util.is_allowed with input as capi_public_operation_api_token_ctx with input.capi.op as {"id" : "GetServiceProviderByID"}
 }
 
 test_capi_allowed_by_api_token_3 {


### PR DESCRIPTION
In line with https://github.com/valitydev/swag-payments/pull/7.