### PR TITLE
TD-176: wapi-pcidss policies

### DIFF
--- a/policies/service/authz/access/data.yaml
+++ b/policies/service/authz/access/data.yaml
@@ -328,8 +328,6 @@ api:
         operations:
           - 'CreateIdentity'
           - 'ListIdentities'
-          - 'StoreBankCard'
-          - 'GetBankCard'
 
     discretionary:
       identity:
@@ -376,3 +374,5 @@ api:
       - 'ListDepositReverts'
       - 'ListDepositAdjustments'
       - 'DownloadFile'
+      - 'StoreBankCard'
+      - 'GetBankCard'

--- a/policies/service/authz/access/data.yaml
+++ b/policies/service/authz/access/data.yaml
@@ -328,6 +328,8 @@ api:
         operations:
           - 'CreateIdentity'
           - 'ListIdentities'
+          - 'StoreBankCard'
+          - 'GetBankCard'
 
     discretionary:
       identity:
@@ -374,6 +376,3 @@ api:
       - 'ListDepositReverts'
       - 'ListDepositAdjustments'
       - 'DownloadFile'
-
-      - 'StoreBankCard'
-      - 'GetBankCard'

--- a/policies/service/authz/access/data.yaml
+++ b/policies/service/authz/access/data.yaml
@@ -374,3 +374,6 @@ api:
       - 'ListDepositReverts'
       - 'ListDepositAdjustments'
       - 'DownloadFile'
+
+      - 'StoreBankCard'
+      - 'GetBankCard'

--- a/policies/service/authz/methods/data.yaml
+++ b/policies/service/authz/methods/data.yaml
@@ -422,9 +422,8 @@ permissions:
           - 'GetProviderIdentityClass'
           - 'ListProviderIdentityLevels'
           - 'GetProviderIdentityLevel'
-          # Only allow tokenization via SessionToken
-          # - 'StoreBankCard'
-          # - 'GetBankCard'
+          - 'StoreBankCard'
+          - 'GetBankCard'
 
   InvoiceAccessToken:
     apis:

--- a/policies/service/authz/methods/data.yaml
+++ b/policies/service/authz/methods/data.yaml
@@ -216,6 +216,8 @@ permissions:
           - 'GetProviderIdentityClass'
           - 'ListProviderIdentityLevels'
           - 'GetProviderIdentityLevel'
+          - 'StoreBankCard'
+          - 'GetBankCard'
 
   ApiKeyToken:
     apis:
@@ -420,6 +422,9 @@ permissions:
           - 'GetProviderIdentityClass'
           - 'ListProviderIdentityLevels'
           - 'GetProviderIdentityLevel'
+          # Only allow tokenization via SessionToken
+          # - 'StoreBankCard'
+          # - 'GetBankCard'
 
   InvoiceAccessToken:
     apis:

--- a/policies/service/authz/roles/data.yaml
+++ b/policies/service/authz/roles/data.yaml
@@ -294,3 +294,5 @@ roles:
           - 'GetReport'
           - 'GetReports'
           - 'DownloadFile'
+          - 'StoreBankCard'
+          - 'GetBankCard'

--- a/test/test/service/authz/api/wapi_test.rego
+++ b/test/test/service/authz/api/wapi_test.rego
@@ -33,6 +33,14 @@ wapi_public_operation_session_token_ctx = util.deepmerge([
     context.op_wapi_empty
 ])
 
+wapi_public_operation_api_key_token_ctx = util.deepmerge([
+    context.env_default,
+    context.requester_default,
+    context.user_administrator,
+    context.api_key_token_valid,
+    context.op_wapi_empty
+])
+
 test_get_residence_allowed {
     util.is_allowed with input as wapi_public_operation_session_token_ctx with input.wapi.op as {"id" : "GetResidence"}
 }
@@ -133,6 +141,34 @@ test_create_identity_allowed {
 test_list_identities_allowed {
     util.is_allowed with input as wapi_public_operation_session_token_ctx with input.wapi.op as {
         "id" : "ListIdentities",
+        "party" : "PARTY"
+    }
+}
+
+test_store_bank_card_allowed {
+    util.is_allowed with input as wapi_public_operation_session_token_ctx with input.wapi.op as {
+        "id" : "StoreBankCard",
+        "party" : "PARTY"
+    }
+}
+
+test_get_bank_card_allowed {
+    util.is_allowed with input as wapi_public_operation_session_token_ctx with input.wapi.op as {
+        "id" : "GetBankCard",
+        "party" : "PARTY"
+    }
+}
+
+test_store_bank_card_forbidden {
+    util.is_forbidden with input as wapi_public_operation_api_key_token_ctx with input.wapi.op as {
+        "id" : "StoreBankCard",
+        "party" : "PARTY"
+    }
+}
+
+test_get_bank_card_forbidden {
+    util.is_forbidden with input as wapi_public_operation_api_key_token_ctx with input.wapi.op as {
+        "id" : "GetBankCard",
         "party" : "PARTY"
     }
 }

--- a/test/test/service/authz/api/wapi_test.rego
+++ b/test/test/service/authz/api/wapi_test.rego
@@ -153,37 +153,31 @@ test_list_identities_allowed {
 
 test_store_bank_card_allowed {
     util.is_allowed with input as wapi_public_operation_session_token_ctx with input.wapi.op as {
-        "id" : "StoreBankCard",
-        "party" : "PARTY"
+        "id" : "StoreBankCard"
     }
     util.is_allowed with input as wapi_public_operation_api_key_token_ctx with input.wapi.op as {
-        "id" : "StoreBankCard",
-        "party" : "PARTY"
+        "id" : "StoreBankCard"
     }
 }
 
 test_get_bank_card_allowed {
     util.is_allowed with input as wapi_public_operation_session_token_ctx with input.wapi.op as {
-        "id" : "GetBankCard",
-        "party" : "PARTY"
+        "id" : "GetBankCard"
     }
     util.is_allowed with input as wapi_public_operation_api_key_token_ctx with input.wapi.op as {
-        "id" : "GetBankCard",
-        "party" : "PARTY"
+        "id" : "GetBankCard"
     }
 }
 
 test_store_bank_card_forbidden {
     util.is_forbidden with input as wapi_public_operation_invalid_token_ctx with input.wapi.op as {
-        "id" : "StoreBankCard",
-        "party" : "PARTY"
+        "id" : "StoreBankCard"
     }
 }
 
 test_get_bank_card_forbidden {
     util.is_forbidden with input as wapi_public_operation_invalid_token_ctx with input.wapi.op as {
-        "id" : "GetBankCard",
-        "party" : "PARTY"
+        "id" : "GetBankCard"
     }
 }
 

--- a/test/test/service/authz/api/wapi_test.rego
+++ b/test/test/service/authz/api/wapi_test.rego
@@ -36,8 +36,14 @@ wapi_public_operation_session_token_ctx = util.deepmerge([
 wapi_public_operation_api_key_token_ctx = util.deepmerge([
     context.env_default,
     context.requester_default,
-    context.user_administrator,
     context.api_key_token_valid,
+    context.op_wapi_empty
+])
+
+wapi_public_operation_invalid_token_ctx = util.deepmerge([
+    context.env_default,
+    context.requester_default,
+    context.invoice_access_token_valid,
     context.op_wapi_empty
 ])
 
@@ -150,6 +156,10 @@ test_store_bank_card_allowed {
         "id" : "StoreBankCard",
         "party" : "PARTY"
     }
+    util.is_allowed with input as wapi_public_operation_api_key_token_ctx with input.wapi.op as {
+        "id" : "StoreBankCard",
+        "party" : "PARTY"
+    }
 }
 
 test_get_bank_card_allowed {
@@ -157,17 +167,21 @@ test_get_bank_card_allowed {
         "id" : "GetBankCard",
         "party" : "PARTY"
     }
+    util.is_allowed with input as wapi_public_operation_api_key_token_ctx with input.wapi.op as {
+        "id" : "GetBankCard",
+        "party" : "PARTY"
+    }
 }
 
 test_store_bank_card_forbidden {
-    util.is_forbidden with input as wapi_public_operation_api_key_token_ctx with input.wapi.op as {
+    util.is_forbidden with input as wapi_public_operation_invalid_token_ctx with input.wapi.op as {
         "id" : "StoreBankCard",
         "party" : "PARTY"
     }
 }
 
 test_get_bank_card_forbidden {
-    util.is_forbidden with input as wapi_public_operation_api_key_token_ctx with input.wapi.op as {
+    util.is_forbidden with input as wapi_public_operation_invalid_token_ctx with input.wapi.op as {
         "id" : "GetBankCard",
         "party" : "PARTY"
     }


### PR DESCRIPTION
Indirect evidence (and some of my own logical thinking) shows that `StoreBankCard` method is currently only used via our dashboards, so I limited it to such. No idea about `GetBankCard`, though (no logs of it being used for the past 14 days).