### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# openpolicyagent/opa:0.56.0
-FROM openpolicyagent/opa@sha256:80c895c2bc7db38ad93aa3773903ea12ba641020a8bccde83c6ad50a7f2a5e73
+FROM openpolicyagent/opa:0.56.0-static
 COPY ./policies /var/opa/roots
 WORKDIR /var/opa/roots
 


### PR DESCRIPTION
Так как в докерфайле указана конкретная ревизия имеджа amd64 становится невозможно сбилдить мультиархитектурный имедж. У агента arm64 есть только для статически слинкованного варианта. Это попытка сделать работающий мультиарх билд вместо текущего неработающего arm64.